### PR TITLE
fix: migrate 'semver' module to std

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,2 +1,2 @@
 export * as path from "https://deno.land/std@0.123.0/path/mod.ts";
-export * as semver from "https://deno.land/x/semver/mod.ts";
+export * as semver from "https://deno.land/std@0.149.0/semver/mod.ts";


### PR DESCRIPTION
The 'semver' module has been migrated to the standard library https://deno.land/std/semver